### PR TITLE
add bulk action collect manually

### DIFF
--- a/src/adverts/claims.spec.ts
+++ b/src/adverts/claims.spec.ts
@@ -1,0 +1,62 @@
+import {
+    getManuallyCollectableClaims,
+    isManuallyCollectableClaim,
+} from './claims'
+import { type AdvertClaim, AdvertClaimType } from './types'
+
+const makeClaim = (overrides: Partial<AdvertClaim> = {}): AdvertClaim => ({
+    quantity: 1,
+    by: 'someone@example.com',
+    at: '2026-01-01T00:00:00.000Z',
+    type: AdvertClaimType.reserved,
+    events: [],
+    canCancel: true,
+    canConvert: true,
+    isOverdue: false,
+    ...overrides,
+})
+
+describe('isManuallyCollectableClaim', () => {
+    it('is true for a convertible, non-collected claim', () => {
+        expect(isManuallyCollectableClaim(makeClaim())).toBe(true)
+    })
+
+    it('is false when the claim cannot be converted', () => {
+        expect(
+            isManuallyCollectableClaim(makeClaim({ canConvert: false }))
+        ).toBe(false)
+    })
+
+    it('is false when the claim is already collected', () => {
+        expect(
+            isManuallyCollectableClaim(
+                makeClaim({ type: AdvertClaimType.collected })
+            )
+        ).toBe(false)
+    })
+})
+
+describe('getManuallyCollectableClaims', () => {
+    it('keeps only manually collectable claims', () => {
+        const eligible = makeClaim()
+        const notConvertible = makeClaim({ canConvert: false })
+        const alreadyCollected = makeClaim({ type: AdvertClaimType.collected })
+
+        expect(
+            getManuallyCollectableClaims([
+                eligible,
+                notConvertible,
+                alreadyCollected,
+            ])
+        ).toEqual([eligible])
+    })
+
+    it('returns an empty array when nothing is eligible', () => {
+        expect(
+            getManuallyCollectableClaims([
+                makeClaim({ canConvert: false }),
+                makeClaim({ type: AdvertClaimType.collected }),
+            ])
+        ).toEqual([])
+    })
+})

--- a/src/adverts/claims.ts
+++ b/src/adverts/claims.ts
@@ -1,0 +1,8 @@
+import { type AdvertClaim, AdvertClaimType } from './types'
+
+export const isManuallyCollectableClaim = (claim: AdvertClaim): boolean =>
+    claim.canConvert && claim.type !== AdvertClaimType.collected
+
+export const getManuallyCollectableClaims = (
+    claims: AdvertClaim[]
+): AdvertClaim[] => claims.filter(isManuallyCollectableClaim)

--- a/src/adverts/components/details/advert-card/ClaimsPanel.tsx
+++ b/src/adverts/components/details/advert-card/ClaimsPanel.tsx
@@ -36,6 +36,7 @@ import {
     useState,
 } from 'react'
 import type { Terms } from 'terms/types'
+import { isManuallyCollectableClaim } from '../../../claims'
 import {
     type Advert,
     type AdvertClaim,
@@ -291,7 +292,7 @@ const ActionButtons: FC<{
                       })
                     : null,
 
-                claim.canConvert && claim.type !== AdvertClaimType.collected
+                isManuallyCollectableClaim(claim)
                     ? makeButton({
                           label: phrase(
                               'ADVERT_CLAIMS_COLLECT_MANUALLY',

--- a/src/adverts/dashboard/AdvertsTable/AdvertsTableContext.ts
+++ b/src/adverts/dashboard/AdvertsTable/AdvertsTableContext.ts
@@ -33,4 +33,5 @@ export const AdvertsTableContext = createContext<AdvertsTableContextType>({
     markAdvertsAsPicked: missing('markAdvertsAsPicked'),
     markAdvertsAsUnpicked: missing('markAdvertsAsUnpicked'),
     createAdvertLabels: missing('createAdvertLabels'),
+    collectClaimsManually: missing('collectClaimsManually'),
 })

--- a/src/adverts/dashboard/AdvertsTable/types.ts
+++ b/src/adverts/dashboard/AdvertsTable/types.ts
@@ -33,6 +33,7 @@ export interface AdvertsTableContextType {
     markAdvertsAsPicked: () => any
     markAdvertsAsUnpicked: () => any
     createAdvertLabels: () => any
+    collectClaimsManually: () => any
 }
 export interface AdvertTableRow {
     id: string

--- a/src/adverts/dashboard/AdvertsTableView.tsx
+++ b/src/adverts/dashboard/AdvertsTableView.tsx
@@ -208,27 +208,28 @@ export const AdvertsTableView: FC<{
             markAdvertsAsUnpicked: () =>
                 bulkUpdateAdverts((id) => markAdvertAsUnpicked(String(id))),
             collectClaimsManually: () =>
-                bulkUpdateAdverts((id) =>
-                    Promise.all(
-                        (
-                            data.adverts.find((a) => a.id === id)?.meta
-                                .claims ?? []
-                        )
-                            .filter(
-                                (claim) =>
-                                    claim.canConvert &&
-                                    claim.type !== AdvertClaimType.collected
-                            )
-                            .map((claim) =>
-                                convertAdvertClaim(
-                                    String(id),
-                                    claim,
-                                    AdvertClaimType.collected,
-                                    null
-                                )
-                            )
+                bulkUpdateAdverts((id) => {
+                    const eligibleClaims = (
+                        data.adverts.find((a) => a.id === id)?.meta.claims ?? []
+                    ).filter(
+                        (claim) =>
+                            claim.canConvert &&
+                            claim.type !== AdvertClaimType.collected
                     )
-                ),
+                    if (eligibleClaims.length !== 1) {
+                        return Promise.reject(
+                            new Error(
+                                `Expected exactly one eligible claim for advert ${id}, found ${eligibleClaims.length}`
+                            )
+                        )
+                    }
+                    return convertAdvertClaim(
+                        String(id),
+                        eligibleClaims[0],
+                        AdvertClaimType.collected,
+                        null
+                    )
+                }),
             createAdvertLabels: () =>
                 window.open(
                     `/api/v1/labels/${selected.toString()}`,

--- a/src/adverts/dashboard/AdvertsTableView.tsx
+++ b/src/adverts/dashboard/AdvertsTableView.tsx
@@ -8,6 +8,7 @@ import {
     type AdvertRestrictionsFilterInput,
     AdvertsContext,
 } from 'adverts'
+import { AdvertClaimType } from 'adverts/types'
 import { AuthContext } from 'auth'
 import { ErrorView } from 'errors'
 import useAbortController from 'hooks/use-abort-controller'
@@ -48,6 +49,7 @@ export const AdvertsTableView: FC<{
         unarchiveAdvert,
         markAdvertAsPicked,
         markAdvertAsUnpicked,
+        convertAdvertClaim,
     } = useContext(AdvertsContext)
 
     const { phrase } = useContext(PhraseContext)
@@ -205,6 +207,28 @@ export const AdvertsTableView: FC<{
                 bulkUpdateAdverts((id) => markAdvertAsPicked(String(id))),
             markAdvertsAsUnpicked: () =>
                 bulkUpdateAdverts((id) => markAdvertAsUnpicked(String(id))),
+            collectClaimsManually: () =>
+                bulkUpdateAdverts((id) =>
+                    Promise.all(
+                        (
+                            data.adverts.find((a) => a.id === id)?.meta
+                                .claims ?? []
+                        )
+                            .filter(
+                                (claim) =>
+                                    claim.canConvert &&
+                                    claim.type !== AdvertClaimType.collected
+                            )
+                            .map((claim) =>
+                                convertAdvertClaim(
+                                    String(id),
+                                    claim,
+                                    AdvertClaimType.collected,
+                                    null
+                                )
+                            )
+                    )
+                ),
             createAdvertLabels: () =>
                 window.open(
                     `/api/v1/labels/${selected.toString()}`,
@@ -222,6 +246,7 @@ export const AdvertsTableView: FC<{
             bulkUpdateAdverts,
             markAdvertAsUnpicked,
             markAdvertAsPicked,
+            convertAdvertClaim,
         ]
     )
     const bulkActions = useMemo(

--- a/src/adverts/dashboard/AdvertsTableView.tsx
+++ b/src/adverts/dashboard/AdvertsTableView.tsx
@@ -8,6 +8,7 @@ import {
     type AdvertRestrictionsFilterInput,
     AdvertsContext,
 } from 'adverts'
+import { getManuallyCollectableClaims } from 'adverts/claims'
 import { AdvertClaimType } from 'adverts/types'
 import { AuthContext } from 'auth'
 import { ErrorView } from 'errors'
@@ -209,12 +210,8 @@ export const AdvertsTableView: FC<{
                 bulkUpdateAdverts((id) => markAdvertAsUnpicked(String(id))),
             collectClaimsManually: () =>
                 bulkUpdateAdverts((id) => {
-                    const eligibleClaims = (
+                    const eligibleClaims = getManuallyCollectableClaims(
                         data.adverts.find((a) => a.id === id)?.meta.claims ?? []
-                    ).filter(
-                        (claim) =>
-                            claim.canConvert &&
-                            claim.type !== AdvertClaimType.collected
                     )
                     if (eligibleClaims.length !== 1) {
                         return Promise.reject(

--- a/src/adverts/dashboard/AdvertsTableView.tsx
+++ b/src/adverts/dashboard/AdvertsTableView.tsx
@@ -211,7 +211,7 @@ export const AdvertsTableView: FC<{
             collectClaimsManually: () =>
                 bulkUpdateAdverts((id) => {
                     const eligibleClaims = getManuallyCollectableClaims(
-                        data.adverts.find((a) => a.id === id)?.meta.claims ?? []
+                        data.adverts.find((a) => a.id === String(id))?.meta.claims ?? []
                     )
                     if (eligibleClaims.length !== 1) {
                         return Promise.reject(

--- a/src/adverts/dashboard/createBulkActions.test.tsx
+++ b/src/adverts/dashboard/createBulkActions.test.tsx
@@ -1,0 +1,110 @@
+import { type AdvertClaim, AdvertClaimType } from 'adverts/types'
+import { describe, expect, it, vi } from 'vitest'
+import { createBulkActions } from './createBulkActions'
+
+const makeClaim = (overrides: Partial<AdvertClaim> = {}): AdvertClaim => ({
+    quantity: 1,
+    by: 'someone@example.com',
+    at: '2026-01-01T00:00:00.000Z',
+    type: AdvertClaimType.reserved,
+    events: [],
+    canCancel: true,
+    canConvert: true,
+    isOverdue: false,
+    ...overrides,
+})
+
+const makeContext = ({
+    claims = [],
+    canEditOwnAdverts = true,
+    collectClaimsManually = vi.fn(),
+}: {
+    claims?: AdvertClaim[]
+    canEditOwnAdverts?: boolean
+    collectClaimsManually?: () => any
+} = {}) =>
+    ({
+        phrase: (_key: string, defaultTemplate: string) => defaultTemplate,
+        roles: { canEditOwnAdverts },
+        fields: {},
+        selectionMatches: (predicate: (advert: any) => boolean) =>
+            predicate({ meta: { claims } }),
+        archiveAdverts: vi.fn(),
+        unarchiveAdverts: vi.fn(),
+        markAdvertsAsPicked: vi.fn(),
+        markAdvertsAsUnpicked: vi.fn(),
+        createAdvertLabels: vi.fn(),
+        collectClaimsManually,
+    }) as unknown as Parameters<typeof createBulkActions>[0]
+
+const getAction = (context: ReturnType<typeof makeContext>) =>
+    createBulkActions(context).find(
+        ({ key }) => key === 'collect-claims-manually'
+    )
+
+describe('createBulkActions - collect-claims-manually', () => {
+    it('is not included when the user lacks canEditOwnAdverts', () => {
+        const context = makeContext({
+            canEditOwnAdverts: false,
+            claims: [makeClaim()],
+        })
+
+        expect(getAction(context)).toBeUndefined()
+    })
+
+    it('has the expected label and icon', () => {
+        const action = getAction(makeContext({ claims: [makeClaim()] }))
+
+        expect(action?.label).toBe('Lämna ut manuellt')
+        expect(action?.icon).toBeTruthy()
+    })
+
+    it('is enabled when exactly one convertible claim exists', () => {
+        const action = getAction(makeContext({ claims: [makeClaim()] }))
+
+        expect(action?.enabled()).toBe(true)
+    })
+
+    it('is disabled when there are no claims', () => {
+        const action = getAction(makeContext({ claims: [] }))
+
+        expect(action?.enabled()).toBe(false)
+    })
+
+    it('is disabled when there is more than one convertible claim', () => {
+        const action = getAction(
+            makeContext({ claims: [makeClaim(), makeClaim()] })
+        )
+
+        expect(action?.enabled()).toBe(false)
+    })
+
+    it('is disabled when the claim cannot be converted', () => {
+        const action = getAction(
+            makeContext({ claims: [makeClaim({ canConvert: false })] })
+        )
+
+        expect(action?.enabled()).toBe(false)
+    })
+
+    it('is disabled when the claim is already collected', () => {
+        const action = getAction(
+            makeContext({
+                claims: [makeClaim({ type: AdvertClaimType.collected })],
+            })
+        )
+
+        expect(action?.enabled()).toBe(false)
+    })
+
+    it('invokes collectClaimsManually when triggered', () => {
+        const collectClaimsManually = vi.fn()
+        const action = getAction(
+            makeContext({ claims: [makeClaim()], collectClaimsManually })
+        )
+
+        action?.action()
+
+        expect(collectClaimsManually).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/adverts/dashboard/createBulkActions.tsx
+++ b/src/adverts/dashboard/createBulkActions.tsx
@@ -11,7 +11,7 @@ import TextSnippetIcon from '@mui/icons-material/TextSnippet'
 import UnarchiveIcon from '@mui/icons-material/Unarchive'
 import WarehouseIcon from '@mui/icons-material/Warehouse'
 import WhereToVoteIcon from '@mui/icons-material/WhereToVote'
-import { AdvertClaimType } from 'adverts/types'
+import { getManuallyCollectableClaims } from 'adverts/claims'
 import type { HaffaUserRoles } from 'auth'
 import { uniqueBy } from 'lib/unique-by'
 import type { PhraseContextType } from 'phrases'
@@ -86,11 +86,7 @@ export const createBulkActions = ({
             enabled: () =>
                 selectionMatches(
                     ({ meta: { claims } }) =>
-                        claims.filter(
-                            (claim) =>
-                                claim.canConvert &&
-                                claim.type !== AdvertClaimType.collected
-                        ).length === 1
+                        getManuallyCollectableClaims(claims).length === 1
                 ),
             action: collectClaimsManually,
         }),

--- a/src/adverts/dashboard/createBulkActions.tsx
+++ b/src/adverts/dashboard/createBulkActions.tsx
@@ -1,6 +1,7 @@
 import AddLocationIcon from '@mui/icons-material/AddLocation'
 import ArchiveIcon from '@mui/icons-material/Archive'
 import CategoryIcon from '@mui/icons-material/Category'
+import ChangeCircleIcon from '@mui/icons-material/ChangeCircle'
 import ContactPageIcon from '@mui/icons-material/ContactPage'
 import DateRangeIcon from '@mui/icons-material/DateRange'
 import LabelIcon from '@mui/icons-material/Label'
@@ -10,6 +11,7 @@ import TextSnippetIcon from '@mui/icons-material/TextSnippet'
 import UnarchiveIcon from '@mui/icons-material/Unarchive'
 import WarehouseIcon from '@mui/icons-material/Warehouse'
 import WhereToVoteIcon from '@mui/icons-material/WhereToVote'
+import { AdvertClaimType } from 'adverts/types'
 import type { HaffaUserRoles } from 'auth'
 import { uniqueBy } from 'lib/unique-by'
 import type { PhraseContextType } from 'phrases'
@@ -47,6 +49,7 @@ export const createBulkActions = ({
     markAdvertsAsPicked,
     markAdvertsAsUnpicked,
     createAdvertLabels,
+    collectClaimsManually,
 }: AdvertsTableContextType & { roles: HaffaUserRoles } & Pick<
         PhraseContextType,
         'phrase'
@@ -72,6 +75,24 @@ export const createBulkActions = ({
             enabled: () =>
                 selectionMatches(({ meta: { canUnpick } }) => canUnpick),
             action: markAdvertsAsUnpicked,
+        }),
+        makeAction(roles.canEditOwnAdverts, {
+            key: 'collect-claims-manually',
+            label: phrase(
+                'ADVERT_CLAIMS_COLLECT_MANUALLY',
+                'Lämna ut manuellt'
+            ),
+            icon: <ChangeCircleIcon />,
+            enabled: () =>
+                selectionMatches(
+                    ({ meta: { claims } }) =>
+                        claims.filter(
+                            (claim) =>
+                                claim.canConvert &&
+                                claim.type !== AdvertClaimType.collected
+                        ).length === 1
+                ),
+            action: collectClaimsManually,
         }),
         makeAction(roles.canEditOwnAdverts, {
             key: 'tags',


### PR DESCRIPTION
This pull request introduces a new bulk action, "Lämna ut manuellt" ("Collect manually"), to the adverts dashboard, allowing users with appropriate permissions to manually mark claims as collected. The implementation adds the necessary context, logic, and tests for this action, ensuring it is only enabled when exactly one convertible claim exists for the selected adverts.

**New Bulk Action: Manual Claim Collection**

* Added a new bulk action (`collect-claims-manually`) to the adverts table, allowing users with `canEditOwnAdverts` permission to manually mark a claim as collected. The action is only enabled if exactly one convertible claim exists and is not already collected. [[1]](diffhunk://#diff-c09954d5fbf4c5f3ebfac81d61e46e410998e4d39d7a3d15c6da207bb3337cc3R79-R96) [[2]](diffhunk://#diff-c09954d5fbf4c5f3ebfac81d61e46e410998e4d39d7a3d15c6da207bb3337cc3R52)
* Integrated the new action into the `AdvertsTableContext` and its type definition, making it available throughout the dashboard. [[1]](diffhunk://#diff-1ac9d704d7201337f3cf9bda83f07f69b0c348a2421b0491f63fd8bbafba0452R36) [[2]](diffhunk://#diff-24f0e011c90b05897f4fca86916635b91c01f8a161a0fb659b6102408f121567R36)
* Implemented the logic for `collectClaimsManually` in `AdvertsTableView`, which finds convertible claims and converts them to the collected state.
* Added tests for the new bulk action, covering its availability, enabling/disabling conditions, and behavior when triggered.

**Supporting Changes**

* Imported `AdvertClaimType` and updated relevant files to support claim type checking and conversion. [[1]](diffhunk://#diff-040c5b86fb6b3ae1fdfc6f3ad13cf26d8b4614d24c2665dd06c3f5475610be84R11) [[2]](diffhunk://#diff-c09954d5fbf4c5f3ebfac81d61e46e410998e4d39d7a3d15c6da207bb3337cc3R14)
* Passed the `convertAdvertClaim` function as context where needed to support the new action. [[1]](diffhunk://#diff-040c5b86fb6b3ae1fdfc6f3ad13cf26d8b4614d24c2665dd06c3f5475610be84R52) [[2]](diffhunk://#diff-040c5b86fb6b3ae1fdfc6f3ad13cf26d8b4614d24c2665dd06c3f5475610be84R249)